### PR TITLE
Update(deps): Bump github.com/functionx/fx-core to v2.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace (
 require (
 	github.com/cosmos/cosmos-sdk v0.45.5
 	github.com/cosmos/ibc-go/v3 v3.1.0
-	github.com/functionx/fx-core v1.2.0-dhobyghaut.0.20220629101316-6cbbe741828a
+	github.com/functionx/fx-core/v2 v2.1.2
 	github.com/gogo/protobuf v1.3.3
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.5

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/functionx/ethermint v0.17.0-fxcore-v2.1.0 h1:uD895zuc1XXqe2P0slc1o513SLZJoys/2cHasJHgg5I=
 github.com/functionx/ethermint v0.17.0-fxcore-v2.1.0/go.mod h1:BmXULZy8lbld5KgNE0zM4b7Dy1irPpL6nsDH11SMNzQ=
-github.com/functionx/fx-core v1.2.0-dhobyghaut.0.20220629101316-6cbbe741828a h1:WCbxcnFMmz39pxtNhscQJfX4FHFA9vfha2UNPV1p6ew=
-github.com/functionx/fx-core v1.2.0-dhobyghaut.0.20220629101316-6cbbe741828a/go.mod h1:Iuklb3xK4zSXnUHcdUtiKj/VeFabu1OFFk0AeGN4S6k=
+github.com/functionx/fx-core/v2 v2.1.2 h1:gaYIP67yZDYbapZ5Z42q682Jsb3mcXVf2m5/L0XbyAY=
+github.com/functionx/fx-core/v2 v2.1.2/go.mod h1:aNzBMQOOAI3B123ncS17jd+0jxaNiRkbUXI7NUdr1bg=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=

--- a/pkg/codec/protobuf_codec.go
+++ b/pkg/codec/protobuf_codec.go
@@ -11,7 +11,7 @@ import (
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	ibcexported "github.com/cosmos/ibc-go/v3/modules/core/exported"
 	ibcclients "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
-	functionxapp "github.com/functionx/fx-core/app"
+	functionxapp "github.com/functionx/fx-core/v2/app"
 )
 
 func RegisterInterfacesAndImpls(interfaceRegistry cosmoscodectypes.InterfaceRegistry) {

--- a/pkg/codec/protobuf_codec_test.go
+++ b/pkg/codec/protobuf_codec_test.go
@@ -1,0 +1,14 @@
+package watcher
+
+import (
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_functionxRegisterInterfaces(t *testing.T) {
+	assert.NotPanics(t, func() {
+		interfaceRegistry := codectypes.NewInterfaceRegistry()
+		functionxRegisterInterfaces(interfaceRegistry)
+	})
+}


### PR DESCRIPTION
In functionx core v2.1.x version, some transaction types of v1 version have been deleted/modified, so if the block before the height of 5,713,000 is upgraded synchronously, there will be a problem of parsing failure. If there is a problem with parsing all transactions before the upgrade height , you can contact me