### PR TITLE
Update(deps): Bump github.com/functionx/fx-core from v2.1.2 to v2.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ replace (
 require (
 	github.com/cosmos/cosmos-sdk v0.45.5
 	github.com/cosmos/ibc-go/v3 v3.1.0
-	github.com/functionx/fx-core/v2 v2.1.2
+	github.com/functionx/fx-core/v2 v2.4.1-0.20221016020639-cadd77ad5da0
 	github.com/gogo/protobuf v1.3.3
 	github.com/streadway/amqp v1.0.0
-	github.com/stretchr/testify v1.7.5
+	github.com/stretchr/testify v1.8.0
 	github.com/tendermint/go-amino v0.16.0
 	github.com/tendermint/tendermint v0.34.20-0.20220517115723-e6f071164839
 )

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ replace (
 require (
 	github.com/cosmos/cosmos-sdk v0.45.5
 	github.com/cosmos/ibc-go/v3 v3.1.0
+	github.com/evmos/ethermint v0.16.0
 	github.com/functionx/fx-core/v2 v2.4.1-0.20221016020639-cadd77ad5da0
 	github.com/gogo/protobuf v1.3.3
 	github.com/streadway/amqp v1.0.0
@@ -52,7 +53,6 @@ require (
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.16 // indirect
-	github.com/evmos/ethermint v0.16.0 // indirect
 	github.com/fbsobreira/gotron-sdk v0.0.0-20211012084317-763989224068 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/functionx/ethermint v0.17.0-fxcore-v2.1.0 h1:uD895zuc1XXqe2P0slc1o513SLZJoys/2cHasJHgg5I=
 github.com/functionx/ethermint v0.17.0-fxcore-v2.1.0/go.mod h1:BmXULZy8lbld5KgNE0zM4b7Dy1irPpL6nsDH11SMNzQ=
-github.com/functionx/fx-core/v2 v2.1.2 h1:gaYIP67yZDYbapZ5Z42q682Jsb3mcXVf2m5/L0XbyAY=
-github.com/functionx/fx-core/v2 v2.1.2/go.mod h1:aNzBMQOOAI3B123ncS17jd+0jxaNiRkbUXI7NUdr1bg=
+github.com/functionx/fx-core/v2 v2.4.1-0.20221016020639-cadd77ad5da0 h1:xzNLJ0RfKsjXsYYLppObO1Q3czxH+o9gJT/m2cJThAQ=
+github.com/functionx/fx-core/v2 v2.4.1-0.20221016020639-cadd77ad5da0/go.mod h1:OF9p9stf8OBPtJdarEA8qtgYfDxZYVCvnDBc/AU7VXk=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
@@ -1015,8 +1015,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
-github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=

--- a/pkg/codec/protobuf_codec.go
+++ b/pkg/codec/protobuf_codec.go
@@ -1,6 +1,8 @@
 package watcher
 
 import (
+	ethercodec "github.com/evmos/ethermint/crypto/codec"
+	ethertypes "github.com/evmos/ethermint/types"
 	"github.com/gogo/protobuf/proto"
 
 	cosmoscodectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -23,6 +25,8 @@ func RegisterInterfacesAndImpls(interfaceRegistry cosmoscodectypes.InterfaceRegi
 
 func functionxRegisterInterfaces(interfaceRegistry cosmoscodectypes.InterfaceRegistry) {
 	functionxapp.ModuleBasics.RegisterInterfaces(interfaceRegistry)
+	ethercodec.RegisterInterfaces(interfaceRegistry)
+	ethertypes.RegisterInterfaces(interfaceRegistry)
 }
 
 func registerTypes(interfaceRegistry cosmoscodectypes.InterfaceRegistry) { // todo: need to nest. Maybe we can remove it. Old code


### PR DESCRIPTION
update dependencies with `go get -v -u github.com/functionx/fx-core/v2@main` 